### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Gather new package version
       id: version
-      uses: anothrNick/github-tag-action@2.12.0
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
@@ -39,12 +39,19 @@ jobs:
 
     - name: Bump package version in pyproject.toml
       run: |
+        . ./venv/bin/activate
         poetry version ${{steps.version.outputs.new_tag}}
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add pyproject.toml
-        git diff-index --quiet HEAD || git commit -m "Updating version of pyproject.toml [skip actions]"
-        git push
+        git commit -m "Updating version of pyproject.toml"
+
+    - name: Push the new pyproject.toml
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        branch: main
+        force: true
 
     - name: Build dist
       run: |
@@ -66,11 +73,17 @@ jobs:
         force: true
         directory: dist
 
-    - name: Create Tag and Release
-      id: create_tag_and_release
-      uses: anothrNick/github-tag-action@2.12.0
+    - name: Create Tag
+      id: tag
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
         DEFAULT_BUMP: patch
         DRY_RUN: false
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.tag.outputs.new_tag }}
+        generate_release_notes: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "*" ]
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for building and testing the project. The most significant changes include downgrading the version of the `github-tag-action`, splitting the tag creation and release steps, and modifying the test workflow to trigger only on pull requests.

### Updates to the build workflow (`.github/workflows/build_dist.yml`):

* Downgraded the `github-tag-action` from version `2.12.0` to `1.61.0` in both the "Gather new package version" and "Create Tag" steps. [[1]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L33-R33) [[2]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L69-R89)
* Added a step to activate the Python virtual environment (`. ./venv/bin/activate`) before bumping the package version in `pyproject.toml`.
* Replaced the inline `git push` command with the `github-push-action` to push changes to the `main` branch, ensuring a more robust and reusable workflow.
* Split the "Create Tag and Release" step into two separate steps: "Create Tag" and "Create Release," using `softprops/action-gh-release` for release creation with autogenerated release notes.

### Updates to the test workflow (`.github/workflows/tests.yml`):

* Removed the `push` trigger for the `main` and `dev` branches, so the workflow now only runs on pull requests targeting any branch.